### PR TITLE
Make the start script able to run from somewhere else than its folder

### DIFF
--- a/dist/linux/start.sh
+++ b/dist/linux/start.sh
@@ -8,4 +8,5 @@ ip -4 -o addr show scope global | awk '{gsub(/\/.*/,"",$4); print $2, "http://"$
 echo ""
 
 echo "Starting server..."
-./websocketd/websocketd --binary --port 31415 ./bin/ws_handler
+WKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$WKDIR/websocketd/websocketd --binary --port 31415 $WKDIR/bin/ws_handler


### PR DESCRIPTION
Make the start script able to run from somewhere else than its folder

```
➜  ~ bricolage/controlloid-server/dist/linux/start.sh 
Server addresses:
br-264db7ba4b0b http://172.24.0.1:31415/
br-4234c81b92c6 http://172.19.0.1:31415/
docker0 http://172.17.0.1:31415/
wlp2s0 http://192.168.0.15:31415/

Starting server...
Tue, 07 May 2019 17:41:39 +0200 | INFO   | server     |  | Serving using application   : /home/remy/bricolage/controlloid-server/dist/linux/bin/ws_handler 
Tue, 07 May 2019 17:41:39 +0200 | INFO   | server     |  | Starting WebSocket server   : ws://caillou:31415/
```