### PR TITLE
Add script for persistent controller device

### DIFF
--- a/dist/linux/persistent.sh
+++ b/dist/linux/persistent.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+rm -f /tmp/controlloid.fifo
+mkfifo /tmp/controlloid.fifo
+trap "exit" INT TERM
+trap "kill 0" EXIT
+while true; do sleep 1d; done >/tmp/controlloid.fifo &
+REMOTE_ADDR=persistent ./bin/ws_handler </tmp/controlloid.fifo >/tmp/controlloid_mappings.bin &
+./websocketd/websocketd \
+	--loglevel=trace --binary --port 31415 --maxforks=1 --staticdir=. \
+	sh -c 'cat /tmp/controlloid_mappings.bin; cat >/tmp/controlloid.fifo'


### PR DESCRIPTION
I had a game that got cranky if a controller got disconnected and was not able to detect new controllers while running.

This is a simple script using fifos to keep a single instance of the `ws_handler` process running as to not destroy and recreate the controller device when reconnecting from the app.

Dunno if this is useful for anyone else, but thought I'd throw it up here incase.